### PR TITLE
Fix print invoice in production

### DIFF
--- a/app/views/spree/admin/orders/_print.pdf.prawn
+++ b/app/views/spree/admin/orders/_print.pdf.prawn
@@ -4,7 +4,7 @@ require 'prawn/layout'
 
 font @font_face
 
-im = Rails.application.assets.find_asset(Spree::PrintInvoice::Config[:print_invoice_logo_path])
+im = Sprockets::Railtie.build_environment(Rails.application).find_asset(Spree::PrintInvoice::Config[:print_invoice_logo_path])
 image im.filename , :at => [0,720], :scale => logo_scale
 
 fill_color "E99323"
@@ -49,4 +49,3 @@ move_down 8
 
 # Footer
 render :partial => "footer"
-


### PR DESCRIPTION
`Rails.application.assets` does not exist when `config.assets.compile = true` but we can use `Railtie.build_environment` in both cases.

It's not enough to use a regular helper like `asset_path` because we're looking for the file path not a url, and reverting to the old join of `Rails.root` requires that we make assumptions about where the user stored their logo or how their app is configured.
