### PR TITLE
Add ffaker to gemspec

### DIFF
--- a/solidus_print_invoice.gemspec
+++ b/solidus_print_invoice.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'ffaker'
 end


### PR DESCRIPTION
ffaker was removed as a runtime dependency of Solidus here:
https://github.com/solidusio/solidus/pull/2163