### PR TITLE
Add prefix to the invoice number and the extension point to customize the generation

### DIFF
--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -7,7 +7,7 @@ Spree::Admin::OrdersController.class_eval do
       format.pdf do
         template = params[:template] || "invoice"
         if (template == "invoice") && Spree::PrintInvoice::Config.use_sequential_number? && !@order.invoice_number.present?
-          @order.invoice_number = Spree::PrintInvoice::Config.increase_invoice_number
+          @order.invoice_number = Spree::PrintInvoice::Config.current_invoice_number_generator_class.new(@order).generate
           @order.invoice_date = Date.today
           @order.save!
         end
@@ -15,5 +15,4 @@ Spree::Admin::OrdersController.class_eval do
       end
     end
   end
-
 end

--- a/app/models/spree/orders/invoice_number_generator/default.rb
+++ b/app/models/spree/orders/invoice_number_generator/default.rb
@@ -1,0 +1,15 @@
+module Spree
+  module Orders
+    module InvoiceNumberGenerator
+      class Default
+        def initialize(order)
+          @order = order
+        end
+
+        def generate
+          Spree::PrintInvoice::Config.prefix + Spree::PrintInvoice::Config.increase_invoice_number
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree/print_invoice_configuration.rb
+++ b/app/models/spree/print_invoice_configuration.rb
@@ -7,6 +7,9 @@ module Spree
     preference :print_invoice_font_face, :string, :default => 'Helvetica'
     preference :print_buttons, :string, :default => 'invoice'
     preference :prawn_options, :hash, :default => {}
+    preference :prefix, :string, :default => ''
+
+    class_name_attribute :current_invoice_number_generator_class, :default => 'Spree::Orders::InvoiceNumberGenerator::Default'
 
     def use_sequential_number?
       print_invoice_next_number.present? && print_invoice_next_number > 0
@@ -17,6 +20,5 @@ module Spree
       set_preference(:print_invoice_next_number, current_invoice_number + 1)
       current_invoice_number
     end
-
   end
 end

--- a/db/migrate/20180117125037_change_invoice_number_type.rb
+++ b/db/migrate/20180117125037_change_invoice_number_type.rb
@@ -1,0 +1,29 @@
+class ChangeInvoiceNumberType < ActiveRecord::Migration[5.1]
+  def up
+    add_column :spree_orders, :invoice_number_tmp, :string
+
+    Spree::Order.reset_column_information
+    Spree::Order.all.find_each do |order|
+      next if order.invoice_number.blank?
+      order.invoice_number_tmp = order.invoice_number
+      order.save(touch: false)
+    end
+
+    remove_column :spree_orders, :invoice_number
+    rename_column :spree_orders, :invoice_number_tmp, :invoice_number
+  end
+
+  def down
+    add_column :spree_orders, :invoice_number_tmp, :integer
+
+    Spree::Order.reset_column_information
+    Spree::Order.all.find_each do |order|
+      next if order.invoice_number.blank?
+      order.invoice_number_tmp = order.invoice_number.to_i
+      order.save(touch: false)
+    end
+
+    remove_column :spree_orders, :invoice_number
+    rename_column :spree_orders, :invoice_number_tmp, :invoice_number
+  end
+end


### PR DESCRIPTION
This PR adds the possibility to specify a prefix for the invoice numbers.
It adds also an extension point (service class), to allow to customize how the number is generated (eg. if we want to include some dynamic data like the year in the number).