### PR TITLE
Spec suite maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,12 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.2 DB=postgres
     - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.2 DB=mysql
     - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,12 @@ else
   gem "rails", "~> 4.2.7"
 end
 
+if branch < 'v2.5'
+  gem 'factory_bot', '4.10.0'
+else
+  gem 'factory_bot', '> 4.10.0'
+end
+
 gem 'pg', '~> 0.21'
 gem 'mysql2', '~> 0.4.10'
 

--- a/app/views/spree/admin/orders/_address.pdf.prawn
+++ b/app/views/spree/admin/orders/_address.pdf.prawn
@@ -20,7 +20,7 @@ end
 
 
 data = [
-  [Spree.t(:billing_address), Spree.t(:shipping_address)], 
+  [I18n.t('spree.billing_address'), I18n.t('spree.shipping_address')],
   [address_info(bill_address), address_info(ship_address) + "\n\nvia #{@order.shipments.first.shipping_method.name}"]
 ]
 

--- a/app/views/spree/admin/orders/_bye.pdf.prawn
+++ b/app/views/spree/admin/orders/_bye.pdf.prawn
@@ -1,6 +1,6 @@
 font "Helvetica", :size => 8, :color => "#444444"
 move_down 10
 
-text Spree.t(:print_note)
+text I18n.t('spree.print_note')
 
 move_down 20

--- a/app/views/spree/admin/orders/_footer.pdf.prawn
+++ b/app/views/spree/admin/orders/_footer.pdf.prawn
@@ -1,5 +1,5 @@
 # data = [
-#   [Spree.t(:footer_left), Spree.t(:footer_left2), Spree.t(:footer_right), Spree.t(:footer_right2)]
+#   [I18n.t('spree.footer_left'), I18n.t('spree.footer_left2'), I18n.t('spree.footer_right'), I18n.t('spree.footer_right2')]
 # ]
 
 # table(data)

--- a/app/views/spree/admin/orders/_header.pdf.prawn
+++ b/app/views/spree/admin/orders/_header.pdf.prawn
@@ -1,8 +1,8 @@
 fill_color "E99323"
 if @hide_prices
-  text Spree.t(:packaging_slip), :align => :right, :style => :bold, :size => 18
+  text I18n.t('spree.packaging_slip'), :align => :right, :style => :bold, :size => 18
 else
-  text Spree.t(:customer_invoice), :align => :right, :style => :bold, :size => 18
+  text I18n.t('spree.customer_invoice'), :align => :right, :style => :bold, :size => 18
 end
 fill_color "000000"
 

--- a/app/views/spree/admin/orders/_line_items_box.pdf.prawn
+++ b/app/views/spree/admin/orders/_line_items_box.pdf.prawn
@@ -3,11 +3,11 @@ data = []
 if @hide_prices
   @column_widths = { 0 => 100, 1 => 165, 2 => 75, 3 => 75 }
   @align = { 0 => :left, 1 => :left, 2 => :right, 3 => :right }
-  data << [Spree.t(:sku), Spree.t(:item_description), Spree.t(:options), Spree.t(:qty)]
+  data << [I18n.t('spree.sku'), I18n.t('spree.item_description'), I18n.t('spree.options'), I18n.t('spree.qty')]
 else
   @column_widths = { 0 => 75, 1 => 205, 2 => 75, 3 => 50, 4 => 75, 5 => 60 }
   @align = { 0 => :left, 1 => :left, 2 => :left, 3 => :right, 4 => :right, 5 => :right}
-  data << [Spree.t(:sku), Spree.t(:item_description), Spree.t(:options), Spree.t(:price), Spree.t(:qty), Spree.t(:total)]
+  data << [I18n.t('spree.sku'), I18n.t('spree.item_description'), I18n.t('spree.options'), I18n.t('spree.price'), I18n.t('spree.qty'), I18n.t('spree.total')]
 end
 
 @order.line_items.each do |item|
@@ -24,7 +24,7 @@ extra_row_count = 0
 unless @hide_prices
   extra_row_count += 1
   data << [""] * 5
-  data << [nil, nil, nil, nil, Spree.t(:subtotal), @order.display_item_total.to_s]
+  data << [nil, nil, nil, nil, I18n.t('spree.subtotal'), @order.display_item_total.to_s]
 
   @order.all_adjustments.eligible.each do |adjustment|
     extra_row_count += 1
@@ -36,7 +36,7 @@ unless @hide_prices
     data << [nil, nil, nil, nil, shipment.shipping_method.name, shipment.display_cost.to_s]
   end
 
-  data << [nil, nil, nil, nil, Spree.t(:total), @order.display_total.to_s]
+  data << [nil, nil, nil, nil, I18n.t('spree.total'), @order.display_total.to_s]
 end
 
 move_down(250)

--- a/app/views/spree/admin/orders/_print.pdf.prawn
+++ b/app/views/spree/admin/orders/_print.pdf.prawn
@@ -9,9 +9,9 @@ image im.filename , :at => [0,720], :scale => logo_scale
 
 fill_color "E99323"
 if @hide_prices
-  text Spree.t(:packaging_slip), :align => :right, :style => :bold, :size => 18
+  text I18n.t('spree.packaging_slip'), :align => :right, :style => :bold, :size => 18
 else
-  text Spree.t(:customer_invoice), :align => :right, :style => :bold, :size => 18
+  text I18n.t('spree.customer_invoice'), :align => :right, :style => :bold, :size => 18
 end
 fill_color "000000"
 
@@ -20,17 +20,17 @@ move_down 4
 if Spree::PrintInvoice::Config.use_sequential_number? && @order.invoice_number.present? && !@hide_prices
 
   font @font_face,  :size => 9,  :style => :bold
-  text "#{Spree.t(:invoice_number)} #{@order.invoice_number}", :align => :right
+  text "#{I18n.t('spree.invoice_number')} #{@order.invoice_number}", :align => :right
 
   move_down 2
   font @font_face, :size => 9
-  text "#{Spree.t(:invoice_date)} #{I18n.l @order.invoice_date}", :align => :right
+  text "#{I18n.t('spree.invoice_date')} #{I18n.l @order.invoice_date}", :align => :right
 
 else
 
   move_down 2
   font @font_face,  :size => 9
-  text "#{Spree.t(:order_number, :number => @order.number)}", :align => :right
+  text "#{I18n.t('spree.order_number', :number => @order.number)}", :align => :right
 
   move_down 2
   font @font_face, :size => 9

--- a/app/views/spree/admin/orders/_print_buttons.html.erb
+++ b/app/views/spree/admin/orders/_print_buttons.html.erb
@@ -2,6 +2,6 @@
   <% buttons = Spree::PrintInvoice::Config[:print_buttons]
      buttons = buttons.split(",").collect{|b| b.strip } %>
   <%  buttons.each do |button| %>
-    <li><%= link_to(Spree.t(button.to_s + "_print"), spree.admin_order_path(@order, :pdf , :template => button), :class => "button fa fa-print") %></li>
+    <li><%= link_to(I18n.t("spree.#{button}_print"), spree.admin_order_path(@order, :pdf , :template => button), :class => "button fa fa-print") %></li>
   <% end %>
-<% end %>  
+<% end %>

--- a/app/views/spree/admin/orders/_totals.pdf.prawn
+++ b/app/views/spree/admin/orders/_totals.pdf.prawn
@@ -1,12 +1,12 @@
 totals = []
 
-totals << [Prawn::Table::Cell.new( :text => Spree.t(:subtotal), :font_style => :bold), @order.display_item_total.to_s]
+totals << [Prawn::Table::Cell.new( :text => I18n.t('spree.subtotal'), :font_style => :bold), @order.display_item_total.to_s]
 
 @order.adjustments.eligible.each do |charge|
   totals << [Prawn::Table::Cell.new( :text => charge.label + ":", :font_style => :bold), charge.display_amount.to_s]
 end
 
-totals << [Prawn::Table::Cell.new( :text => Spree.t(:order_total), :font_style => :bold), @order.display_total.to_s]
+totals << [Prawn::Table::Cell.new( :text => I18n.t('spree.order_total'), :font_style => :bold), @order.display_total.to_s]
 
 bounding_box [bounds.right - 500, bounds.bottom + (totals.length * 18)], :width => 500 do
   table totals,

--- a/spec/requests/admin_orders_controller_spec.rb
+++ b/spec/requests/admin_orders_controller_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 RSpec.describe "Order Invoice Generation" do
+  before do
+    ActionController::Base.allow_forgery_protection = false
+  end
+
+  after do
+    ActionController::Base.allow_forgery_protection = true
+  end
+
   describe "GET show" do
     let(:order) { FactoryBot.create(:completed_order_with_totals) }
     let(:user) { FactoryBot.create(:admin_user, password: "testing123") }


### PR DESCRIPTION
This PR aims to:

* Fix most `Spree.t` deprecation warnings
* Set forgery protection to `false` on admin orders controller spec
* Remove Solidus v2.2 support from Travis
* Lock FactoryBot to v4.10 for Solidus versions lower than 2.5 for compatibility reasons