### PR TITLE
Add Solidus v2.8 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,12 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
     - SOLIDUS_BRANCH=v2.8 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql
     - SOLIDUS_BRANCH=v2.6 DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,12 @@ env:
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
+    - SOLIDUS_BRANCH=v2.8 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
     - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql
     - SOLIDUS_BRANCH=v2.6 DB=mysql
     - SOLIDUS_BRANCH=v2.7 DB=mysql
+    - SOLIDUS_BRANCH=v2.8 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql


### PR DESCRIPTION
As per @kennyadsl's request, this PR also removes support for Solidus v2.3 as tomorrow (**01/31/19**) is the last day before reaching EOL; this patch should only be merged **past** the date previously mentioned.