### PR TITLE
Prepare prawn template handlers to support rails 6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,8 @@
 require:
-  - solidus_extension_dev_tools/rubocop
+  - solidus_dev_support/rubocop
 
 inherit_gem:
-  solidus_extension_dev_tools: .rubocop.extension.yml
+  solidus_dev_support: .rubocop.yml
 
 AllCops:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,6 @@ else
   gem 'sqlite3'
 end
 
-gem 'solidus_extension_dev_tools', github: 'solidusio-contrib/solidus_extension_dev_tools'
+gem 'solidus_dev_support', github: 'solidusio-contrib/solidus_dev_support'
 
 gemspec

--- a/lib/prawn_handler.rb
+++ b/lib/prawn_handler.rb
@@ -9,8 +9,9 @@ module ActionView
         Template.register_template_handler :prawn, self
       end
 
-      def self.call(template)
-        %(extend #{DocumentProxy}; #{template.source}; pdf.render)
+      def self.call(template, source = nil)
+        source ||= template.source
+        %(extend #{DocumentProxy}; #{source}; pdf.render)
       end
 
       module DocumentProxy

--- a/solidus_print_invoice.gemspec
+++ b/solidus_print_invoice.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus', ['>= 1.0', '< 3']
   s.add_dependency "solidus_support"
 
-  s.add_development_dependency 'solidus_extension_dev_tools'
+  s.add_development_dependency 'solidus_dev_support'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,10 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 
-require 'solidus_extension_dev_tools/rspec/coverage'
+require 'solidus_dev_support/rspec/coverage'
 
 require File.expand_path('dummy/config/environment.rb', __dir__)
 
-require 'solidus_extension_dev_tools/rspec/feature_helper'
+require 'solidus_dev_support/rspec/feature_helper'
 
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }


### PR DESCRIPTION
The only breaking change is that template handers now receive
template name in a separate parameter