### PR TITLE
Fixes find_asset in Production

### DIFF
--- a/app/views/spree/admin/orders/_print.pdf.prawn
+++ b/app/views/spree/admin/orders/_print.pdf.prawn
@@ -4,7 +4,7 @@ require 'prawn/layout'
 
 font @font_face
 
-im = Rails.application.assets.find_asset(Spree::PrintInvoice::Config[:print_invoice_logo_path])
+im = Sprockets::Railtie.build_environment(Rails.application).find_asset(Spree::PrintInvoice::Config[:print_invoice_logo_path])
 image im.filename , :at => [0,720], :scale => logo_scale
 
 fill_color "E99323"


### PR DESCRIPTION
Hello.

This is an old issue in production mode. The find_asset method from the assets is not available in production, so it is causing the prawn template to raise an exception. The fix now works for both development and production.

Regards