### PR TITLE
Fixes print invoice route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,6 @@
 
 Spree::Core::Engine.routes.draw do
   namespace :admin do
-    resources :orders do
-      member do
-        get :show
-      end
-    end
+    resources :orders, only: [:new, :show]
   end
 end


### PR DESCRIPTION
Hello. I found an error when the `solidus_print_invoice` is installed. Steps to reproduce.

1. Install extension `solidus_print_invoice`
2. Login as admin
3. Go to `orders` menu and click the button `New Order`.
4. You get the exception `ActiveRecord::RecordNotFound in Spree::Admin::OrdersController#show` 

Once you click New Order, you get the error in the screenshots. I think that the error is because the print invoice plugin is extending the `show` method for the `orders_controller`. This method tries to load the order and it gets an error as the `params[:id] = "new"`. I think the route `/admin/orders/new` is clashing with the route `/admin/orders/:id`. So I think the router thinks the id for loading order is the word "new" and of course there is no order with that ID in the system, raising a `record not found execption`

This fix is to create a new method for printing the invoice called `print_invoice`, so in that way the `show` order is used by default solidus and the print invoice has its own method.

Let me know what you think.
![Screenshot from 2020-03-18 09-24-36](https://user-images.githubusercontent.com/11409554/77161503-bd835080-6aa1-11ea-998a-7d2be5e5828d.png)
![Screenshot from 2020-03-18 09-24-52](https://user-images.githubusercontent.com/11409554/77161504-be1be700-6aa1-11ea-9c43-88ddd8383774.png)
![Screenshot from 2020-03-18 09-26-26](https://user-images.githubusercontent.com/11409554/77161507-beb47d80-6aa1-11ea-8bc6-0b3d33283b82.png)
![Screenshot from 2020-03-18 09-26-57](https://user-images.githubusercontent.com/11409554/77161520-cb38d600-6aa1-11ea-98f1-f6eb81dd7f10.png)

