### PR TITLE
Install browser-tools on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,18 @@ orbs:
   # or goes EOL.
   solidusio_extensions: solidusio/extensions@volatile
 
+  browser-tools: circleci/browser-tools@1.1
+
 jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
+      - browser-tools/install-browser-tools
       - solidusio_extensions/run-tests
   run-specs-with-mysql:
     executor: solidusio_extensions/mysql
     steps:
+      - browser-tools/install-browser-tools
       - solidusio_extensions/run-tests
 
 workflows:

--- a/lib/solidus_print_invoice/engine.rb
+++ b/lib/solidus_print_invoice/engine.rb
@@ -2,6 +2,7 @@
 
 require 'spree/core'
 require 'deface'
+require_relative '../../app/models/spree/print_invoice_configuration'
 
 module SolidusPrintInvoice
   class Engine < Rails::Engine

--- a/solidus_print_invoice.gemspec
+++ b/solidus_print_invoice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   end
 
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '~> 2.4'
+  s.required_ruby_version = '>= 2.4'
 
   s.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
-  s.add_dependency 'solidus_support', '~> 0.5'
+  s.add_dependency 'solidus_support', '~> 0.9'
   s.add_dependency 'deface'
   s.add_dependency 'prawn', '1.0.0'
   s.add_dependency 'solidus', ['>= 1.0', '< 4']


### PR DESCRIPTION
Required to install Google Chrome used by selenium driver

Copied from https://github.com/solidusio-contrib/solidus_gdpr/pull/41/commits/5ad3e253882e9c155ca94b9855b182f8f090f045 and inspired by https://github.com/solidusio/circleci-orbs-extensions/pull/45.

There were two other problems I've fixed in this PR:
- Ruby version requirements didn't allow newer Rubies
- Rails must have changed how it autoloads engines somehow, so I had to require the model file relied upon in `engine.rb` explicitly. I'm all ears for suggestions on how to do this better, but it does make the tests pass!